### PR TITLE
[Fix] IllegalArgumentException on player.setHealth(20D)

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/game/GamePlayer.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/game/GamePlayer.java
@@ -128,7 +128,8 @@ public class GamePlayer {
         this.player.setFoodLevel(20);
         this.player.setSaturation(10);
         this.player.setExhaustion(0);
-        this.player.setHealth(20.0D);
+        this.player.setMaxHealth(20D);
+        this.player.setHealth(this.player.getMaxHealth());
         this.player.setFireTicks(0);
         this.player.setGameMode(GameMode.SURVIVAL);
 


### PR DESCRIPTION
Fixed IllegalArgument Exception on player.setHealth(20D) if the player's attribute generic_max_health base value is lower than 20.

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Tested minecraft versions:** 1.15.1
According to [javadoc for spigot 1.9](https://helpch.at/docs/1.9.4/org/bukkit/entity/Player.html), this fix will be compatible with all supported version.
I do not test other part of code is compatible with 1.15.1

### Screenshots (if appropriate)
none.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
