### PR TITLE
enable blast proof glass.

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
@@ -124,6 +124,7 @@ public class Configurator {
         checkOrSetConfig(modify, "disable-hunger", false);
         checkOrSetConfig(modify, "automatic-coloring-in-shop", true);
         checkOrSetConfig(modify, "sell-max-64-per-click-in-shop", true);
+        checkOrSetConfig(modify, "destroy-placed-blocks-by-explosion-except", "");
         checkOrSetConfig(modify, "destroy-placed-blocks-by-explosion", true);
         checkOrSetConfig(modify, "holo-above-bed", true);
         checkOrSetConfig(modify, "allow-spectator-join", false);

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
@@ -99,7 +99,7 @@ public class WorldListener implements Listener {
             if (game.getStatus() == GameStatus.RUNNING || game.getStatus() == GameStatus.GAME_END_CELEBRATING) {
                 if (GameCreator.isInArea(event.getLocation(), game.getPos1(), game.getPos2())) {
                     if (destroyPlacedBlocksByExplosion) {
-                        event.blockList().removeIf(block -> (explosionExceptionTypeName!=null && explosionExceptionTypeName!="" && block.getType().name().contains(explosionExceptionTypeName)) || !game.isBlockAddedDuringGame(block.getLocation()));
+                        event.blockList().removeIf(block -> (explosionExceptionTypeName!=null && !explosionExceptionTypeName.equals("") && block.getType().name().contains(explosionExceptionTypeName)) || !game.isBlockAddedDuringGame(block.getLocation()));
                     } else {
                         event.blockList().clear();
                     }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
@@ -92,14 +92,14 @@ public class WorldListener implements Listener {
         }
         
         String explosionExceptionTypeName = Main.getConfigurator().config.getString("destroy-placed-blocks-by-explosion-except", null);
-        Boolean destroyPlacedBlocksByExplosion = Main.getConfigurator().config.getBoolean("destroy-placed-blocks-by-explosion", true);
+        boolean destroyPlacedBlocksByExplosion = Main.getConfigurator().config.getBoolean("destroy-placed-blocks-by-explosion", true);
 
         for (String s : Main.getGameNames()) {
             Game game = Main.getGame(s);
             if (game.getStatus() == GameStatus.RUNNING || game.getStatus() == GameStatus.GAME_END_CELEBRATING) {
                 if (GameCreator.isInArea(event.getLocation(), game.getPos1(), game.getPos2())) {
                     if (destroyPlacedBlocksByExplosion) {
-                        event.blockList().removeIf(block -> (explosionExceptionTypeName!=null && block.getType().name().contains(explosionExceptionTypeName)) || !game.isBlockAddedDuringGame(block.getLocation()));
+                        event.blockList().removeIf(block -> (explosionExceptionTypeName!=null && explosionExceptionTypeName!="" && block.getType().name().contains(explosionExceptionTypeName)) || !game.isBlockAddedDuringGame(block.getLocation()));
                     } else {
                         event.blockList().clear();
                     }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
@@ -90,13 +90,16 @@ public class WorldListener implements Listener {
         if (event.isCancelled()) {
             return;
         }
+        
+        String explosionExceptionTypeName = Main.getConfigurator().config.getString("destroy-placed-blocks-by-explosion-except", null);
+        Boolean destroyPlacedBlocksByExplosion = Main.getConfigurator().config.getBoolean("destroy-placed-blocks-by-explosion", true);
 
         for (String s : Main.getGameNames()) {
             Game game = Main.getGame(s);
             if (game.getStatus() == GameStatus.RUNNING || game.getStatus() == GameStatus.GAME_END_CELEBRATING) {
                 if (GameCreator.isInArea(event.getLocation(), game.getPos1(), game.getPos2())) {
-                    if (Main.getConfigurator().config.getBoolean("destroy-placed-blocks-by-explosion", true)) {
-                        event.blockList().removeIf(block -> !game.isBlockAddedDuringGame(block.getLocation()));
+                    if (destroyPlacedBlocksByExplosion) {
+                        event.blockList().removeIf(block -> (explosionExceptionTypeName!=null && block.getType().name().contains(explosionExceptionTypeName)) || !game.isBlockAddedDuringGame(block.getLocation()));
                     } else {
                         event.blockList().clear();
                     }


### PR DESCRIPTION
## Description
Enable explosion-proof material to be configured in config.yml.  It works for the term "GLASS"; it protects coloured glass from explosions.  I'd guess that a similar effect could be achieved by tweaking resistance from the shop.yml, but this was faster than figuring out how to do that.

If you would like to include this I can update the documentation as well, let me know if you need that.  

**Tested Minecraft versions:**
1.15.2

### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [X] My code follows the code style of this project.
-   [X] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
