### PR TITLE
Implement option to bypass flight in arenas

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
@@ -130,7 +130,7 @@ public class Configurator {
         checkOrSetConfig(modify, "allow-spectator-join", false);
         checkOrSetConfig(modify, "disable-server-message.player-join", false);
         checkOrSetConfig(modify, "disable-server-message.player-leave", false);
-        checkOrSetConfig(modify, "disable-flight", false);
+        checkOrSetConfig(modify, "disable-flight", true);
         checkOrSetConfig(modify, "respawn-cooldown.enabled", true);
         checkOrSetConfig(modify, "respawn-cooldown.time", 5);
         checkOrSetConfig(modify, "stop-team-spawners-on-die", false);

--- a/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
@@ -130,6 +130,7 @@ public class Configurator {
         checkOrSetConfig(modify, "allow-spectator-join", false);
         checkOrSetConfig(modify, "disable-server-message.player-join", false);
         checkOrSetConfig(modify, "disable-server-message.player-leave", false);
+        checkOrSetConfig(modify, "disable-flight", false);
         checkOrSetConfig(modify, "respawn-cooldown.enabled", true);
         checkOrSetConfig(modify, "respawn-cooldown.time", 5);
         checkOrSetConfig(modify, "stop-team-spawners-on-die", false);

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
@@ -576,7 +576,7 @@ public class PlayerListener implements Listener {
 
         Player player = event.getPlayer();
         if (Main.isPlayerInGame(player) && !Main.getPlayerGameProfile(player).isSpectator
-               && (!player.hasPermission("bw.bypass.flight") || Main.getConfigurator().config.getBoolean("disable-flight"))) {
+               && (!player.hasPermission("bw.bypass.flight") && Main.getConfigurator().config.getBoolean("disable-flight"))) {
             event.setCancelled(true);
         }
     }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
@@ -573,11 +573,11 @@ public class PlayerListener implements Listener {
         if (event.isCancelled()) {
             return;
         }
+
         Player player = event.getPlayer();
-        if (Main.isPlayerInGame(player)) {
-            if (!Main.getPlayerGameProfile(player).isSpectator) {
-                event.setCancelled(true);
-            }
+        if (Main.isPlayerInGame(player) && !Main.getPlayerGameProfile(player).isSpectator
+               && (!player.hasPermission("bw.bypass.flight") || Main.getConfigurator().config.getBoolean("disable-flight"))) {
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
## Description
This change allows the player to be able to fly in the game if there is permission or the option is not disabled. Someone asked me "how to allow flying in the arena?". That’s why I added this option because someone wanted it.

Closes #165 

**Tested minecraft versions:** Should works without any test, because this has no any version-compatibility checks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.

⬆️ _The 2 checklists are the responsibility of GitHub Action and the repository author._

**EDIT: Do I add elytra check?**