### PR TITLE
Fix null pointer errors using Citizens shop

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/config/Configurator.java
@@ -167,6 +167,7 @@ public class Configurator {
         checkOrSetConfig(modify, "shop.items-on-row", 9);
         checkOrSetConfig(modify, "shop.show-page-numbers", true);
         checkOrSetConfig(modify, "shop.inventory-type", "CHEST");
+        checkOrSetConfig(modify, "shop.citizens-enabled", false);
         
         checkOrSetConfig(modify, "items.jointeam", "COMPASS");
         checkOrSetConfig(modify, "items.leavegame", "SLIME_BALL");

--- a/plugin/src/main/java/org/screamingsandals/bedwars/game/Game.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/game/Game.java
@@ -3057,6 +3057,9 @@ public class Game implements org.screamingsandals.bedwars.api.game.Game {
 
     @Override
     public boolean isEntityShop(Entity entity) {
+        if(Main.getConfigurator().config.getBoolean("shop.citizens-enabled", false))
+            return false;
+
         for (GameStore store : gameStore) {
             if (store.getEntity().equals(entity)) {
                 return true;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Addon fixes that checks if entity is shop, but in the addon the shops are unregistered and hence produces a null pointer exception. 
**Tested minecraft versions:**
1.15
### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [ x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
