### PR TITLE
fix for issue #148

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
@@ -264,6 +264,8 @@ public class PlayerListener implements Listener {
                 event.setRespawnLocation(gPlayer.getGame().getLobbySpawn());
                 return;
             }
+            // clear inventory to fix issue 148
+            event.getPlayer().getInventory().clear();
             if (gPlayer.isSpectator) {
                 if (team == null) {
                     event.setRespawnLocation(gPlayer.getGame().makeSpectator(gPlayer, true));


### PR DESCRIPTION
## Description
This is my fix for issue #148. As expected, it is enough to clear the inventory on respawn (which is good, because Player.isOnGround apparently cannot be trusted, and for that reason is marked deprecated in 1.16).

I tested this with a fresh spigot 1.16.1 with no other plugins. Both stuff in the crafting grid and unter the cursor are gone after respawn. 

**Tested minecraft versions:** 1.16.1

### Screenshots (if appropriate)
n/a

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
