### PR TITLE
Fix for WarpPowder

### DIFF
--- a/api/src/main/java/org/screamingsandals/bedwars/api/special/WarpPowder.java
+++ b/api/src/main/java/org/screamingsandals/bedwars/api/special/WarpPowder.java
@@ -7,10 +7,10 @@ import org.bukkit.inventory.ItemStack;
  */
 public interface WarpPowder extends SpecialItem {
     /**
-     * @param removeSpecial
+     * @param unregisterSpecial
      * @param showMessage
      */
-    public void cancelTeleport(boolean removeSpecial, boolean showMessage);
+    public void cancelTeleport(boolean unregisterSpecial, boolean showMessage);
 
     /**
      * @return

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/WarpPowder.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/WarpPowder.java
@@ -1,5 +1,6 @@
 package org.screamingsandals.bedwars.special;
 
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -45,6 +46,13 @@ public class WarpPowder extends SpecialItem implements org.screamingsandals.bedw
         if (showMessage) {
             player.sendMessage(i18nc("specials_warp_powder_canceled", game.getCustomPrefix()));
         }
+
+        if (player.getInventory().firstEmpty() == -1 || !player.getInventory().contains(item)) {
+            player.getWorld().dropItemNaturally(player.getLocation(), item);
+        } else {
+            player.getInventory().addItem(item);
+        }
+        player.updateInventory();
     }
 
     @Override
@@ -52,6 +60,21 @@ public class WarpPowder extends SpecialItem implements org.screamingsandals.bedw
         game.registerSpecialItem(this);
 
         player.sendMessage(i18nc("specials_warp_powder_started", game.getCustomPrefix()).replace("%time%", Double.toString(teleportingTime)));
+
+        if (item.getAmount() > 1) {
+            item.setAmount(item.getAmount() - 1);
+        } else {
+            try {
+                if (player.getInventory().getItemInOffHand().equals(item)) {
+                    player.getInventory().setItemInOffHand(new ItemStack(Material.AIR));
+                } else {
+                    player.getInventory().remove(item);
+                }
+            } catch (Throwable e) {
+                player.getInventory().remove(item);
+            }
+        }
+        player.updateInventory();
 
         teleportingTask = new BukkitRunnable() {
 

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/WarpPowder.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/WarpPowder.java
@@ -47,7 +47,7 @@ public class WarpPowder extends SpecialItem implements org.screamingsandals.bedw
             player.sendMessage(i18nc("specials_warp_powder_canceled", game.getCustomPrefix()));
         }
 
-        if (player.getInventory().firstEmpty() == -1 || !player.getInventory().contains(item)) {
+        if (player.getInventory().firstEmpty() == -1 && !player.getInventory().contains(item)) {
             player.getWorld().dropItemNaturally(player.getLocation(), item);
         } else {
             player.getInventory().addItem(item);
@@ -81,7 +81,7 @@ public class WarpPowder extends SpecialItem implements org.screamingsandals.bedw
             @Override
             public void run() {
                 if (teleportingTime == 0) {
-                    cancelTeleport(true, false);
+                    game.unregisterSpecialItem(WarpPowder.this);
                     PlayerUtils.teleportPlayer(player, team.getTeamSpawn());
                 } else {
                     SpawnEffects.spawnEffect(game, player, "game-effects.warppowdertick");

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/WarpPowder.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/WarpPowder.java
@@ -32,27 +32,26 @@ public class WarpPowder extends SpecialItem implements org.screamingsandals.bedw
     }
 
     @Override
-    public void cancelTeleport(boolean removeSpecial, boolean showMessage) {
+    public void cancelTeleport(boolean unregisterSpecial, boolean showMessage) {
         try {
             teleportingTask.cancel();
         } catch (Exception ignored) {
-
         }
 
-        if (removeSpecial) {
+        if (unregisterSpecial) {
             game.unregisterSpecialItem(this);
+        } else {
+            if (player.getInventory().firstEmpty() == -1 && !player.getInventory().contains(item)) {
+                player.getWorld().dropItemNaturally(player.getLocation(), item);
+            } else {
+                player.getInventory().addItem(item);
+            }
+            player.updateInventory();
         }
 
         if (showMessage) {
             player.sendMessage(i18nc("specials_warp_powder_canceled", game.getCustomPrefix()));
         }
-
-        if (player.getInventory().firstEmpty() == -1 && !player.getInventory().contains(item)) {
-            player.getWorld().dropItemNaturally(player.getLocation(), item);
-        } else {
-            player.getInventory().addItem(item);
-        }
-        player.updateInventory();
     }
 
     @Override
@@ -81,7 +80,7 @@ public class WarpPowder extends SpecialItem implements org.screamingsandals.bedw
             @Override
             public void run() {
                 if (teleportingTime == 0) {
-                    game.unregisterSpecialItem(WarpPowder.this);
+                    cancelTeleport(true, false);
                     PlayerUtils.teleportPlayer(player, team.getTeamSpawn());
                 } else {
                     SpawnEffects.spawnEffect(game, player, "game-effects.warppowdertick");

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
@@ -126,7 +126,6 @@ public class WarpPowderListener implements Listener {
 
         WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
         if (warpPowder != null) {
-            player.sendMessage("cancelled");
             warpPowder.cancelTeleport(false, true);
         }
     }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
@@ -52,53 +52,35 @@ public class WarpPowderListener implements Listener {
                         String unhidden = APIUtils.unhashFromInvisibleStringStartsWith(stack, WARP_POWDER_PREFIX);
 
                         if (unhidden != null) {
-                            if (!game.isDelayActive(player, WarpPowder.class)) {
-                                event.setCancelled(true);
+                            event.setCancelled(true);
 
-                                int teleportTime = Integer.parseInt(unhidden.split(":")[2]);
-                                int delay = Integer.parseInt(unhidden.split(":")[3]);
-                                WarpPowder warpPowder = new WarpPowder(game, event.getPlayer(),
-                                        game.getTeamOfPlayer(event.getPlayer()), stack, teleportTime);
+                            int teleportTime = Integer.parseInt(unhidden.split(":")[2]);
+                            int delay = Integer.parseInt(unhidden.split(":")[3]);
+                            WarpPowder warpPowder = new WarpPowder(game, event.getPlayer(),
+                                    game.getTeamOfPlayer(event.getPlayer()), stack, teleportTime);
 
-                                if (event.getPlayer().getLocation().getBlock().getRelative(BlockFace.DOWN)
-                                        .getType() == Material.AIR) {
-                                    return;
-                                }
-
-                                if (delay > 0) {
-                                    DelayFactory delayFactory = new DelayFactory(delay, warpPowder, player, game);
-                                    game.registerDelay(delayFactory);
-                                }
-
-                                warpPowder.runTask();
-
-                                if (stack.getAmount() > 1) {
-                                    stack.setAmount(stack.getAmount() - 1);
-                                } else {
-                                    try {
-                                        if (player.getInventory().getItemInOffHand().equals(stack)) {
-                                            player.getInventory().setItemInOffHand(new ItemStack(Material.AIR));
-                                        } else {
-                                            player.getInventory().remove(stack);
-                                        }
-                                    } catch (Throwable e) {
-                                        player.getInventory().remove(stack);
-                                    }
-                                }
-
-                                player.updateInventory();
-                            } else {
-                                event.setCancelled(true);
-
-                                int delay = game.getActiveDelay(player, RescuePlatform.class).getRemainDelay();
-                                MiscUtils.sendActionBarMessage(player, i18nonly("special_item_delay").replace("%time%", String.valueOf(delay)));
+                            if (event.getPlayer().getLocation().getBlock().getRelative(BlockFace.DOWN)
+                                    .getType() == Material.AIR) {
+                                return;
                             }
+
+                            if (delay > 0) {
+                                DelayFactory delayFactory = new DelayFactory(delay, warpPowder, player, game);
+                                game.registerDelay(delayFactory);
+                            }
+
+                            warpPowder.runTask();
+                        } else {
+                            event.setCancelled(true);
+                            int delay = game.getActiveDelay(player, RescuePlatform.class).getRemainDelay();
+                            MiscUtils.sendActionBarMessage(player, i18nonly("special_item_delay").replace("%time%", String.valueOf(delay)));
                         }
                     }
                 }
             }
         }
     }
+
 
     @EventHandler
     public void onDamage(EntityDamageEvent event) {
@@ -122,27 +104,6 @@ public class WarpPowderListener implements Listener {
         WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
         if (warpPowder != null) {
             warpPowder.cancelTeleport(true, true);
-        }
-    }
-
-    @EventHandler
-    public void onDrop(PlayerDropItemEvent event) {
-        Player player = event.getPlayer();
-        if (event.isCancelled() || !Main.isPlayerInGame(player)) {
-            return;
-        }
-
-        GamePlayer gPlayer = Main.getPlayerGameProfile(player);
-        Game game = gPlayer.getGame();
-        if (gPlayer.isSpectator) {
-            return;
-        }
-
-        WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
-        if (warpPowder != null) {
-            if (warpPowder.getStack().equals(event.getItemDrop().getItemStack())) {
-                event.setCancelled(true);
-            }
         }
     }
 

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
@@ -103,8 +103,7 @@ public class WarpPowderListener implements Listener {
 
         WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
         if (warpPowder != null) {
-            player.sendMessage("cancelled");
-            warpPowder.cancelTeleport(true, true);
+            warpPowder.cancelTeleport(false, true);
         }
     }
 
@@ -128,7 +127,7 @@ public class WarpPowderListener implements Listener {
         WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
         if (warpPowder != null) {
             player.sendMessage("cancelled");
-            warpPowder.cancelTeleport(true, true);
+            warpPowder.cancelTeleport(false, true);
         }
     }
 

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/WarpPowderListener.java
@@ -103,6 +103,7 @@ public class WarpPowderListener implements Listener {
 
         WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
         if (warpPowder != null) {
+            player.sendMessage("cancelled");
             warpPowder.cancelTeleport(true, true);
         }
     }
@@ -126,6 +127,7 @@ public class WarpPowderListener implements Listener {
 
         WarpPowder warpPowder = (WarpPowder) game.getFirstActivedSpecialItemOfPlayer(player, WarpPowder.class);
         if (warpPowder != null) {
+            player.sendMessage("cancelled");
             warpPowder.cancelTeleport(true, true);
         }
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Remove warppowder when player starts teleporting (and give it back if it got cancelled). It fixes an infinite usage of it.
**Tested minecraft versions:** 1.16.4

### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
