### PR TITLE
Add Option to Make Shop Items Permanent

### DIFF
--- a/api/src/main/java/org/screamingsandals/bedwars/api/events/BedwarsApplyPropertyToItem.java
+++ b/api/src/main/java/org/screamingsandals/bedwars/api/events/BedwarsApplyPropertyToItem.java
@@ -88,6 +88,14 @@ public class BedwarsApplyPropertyToItem extends Event {
      * @param key
      * @return
      */
+    public boolean hasProperty(String key) {
+        return this.properties.containsKey(key);
+    }
+
+    /**
+     * @param key
+     * @return
+     */
     public String getStringProperty(String key) {
         return this.properties.get(key).toString();
     }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/game/Game.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/game/Game.java
@@ -1460,6 +1460,7 @@ public class Game implements org.screamingsandals.bedwars.api.game.Game {
                         Debug.warn("You have wrongly configured gived-player-respawn-items!", true);
                     }
                 }
+                MiscUtils.giveItemsToPlayer(gamePlayer.getPermaItemsPurchased(), player, currentTeam.getColor());
 
                 if (configurationContainer.getOrDefault(ConfigurationContainer.KEEP_ARMOR, Boolean.class, false)) {
                     final ItemStack[] armorContents = gamePlayer.getGameArmorContents();

--- a/plugin/src/main/java/org/screamingsandals/bedwars/game/GamePlayer.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/game/GamePlayer.java
@@ -20,6 +20,7 @@ public class GamePlayer {
     private Game game = null;
     private String latestGame = null;
     private StoredInventory oldInventory = new StoredInventory();
+    private List<ItemStack> permaItemsPurchased = new ArrayList<>();
     private List<Player> hiddenPlayers = new ArrayList<>();
     private ItemStack[] armorContents = null;
 
@@ -79,6 +80,18 @@ public class GamePlayer {
 
     public boolean canJoinFullGame() {
         return player.hasPermission("bw.vip.forcejoin");
+    }
+
+    public List<ItemStack> getPermaItemsPurchased() {
+        return permaItemsPurchased;
+    }
+
+    private void resetPermaItems() {
+        this.permaItemsPurchased.clear();
+    }
+
+    public void addPermaItem(ItemStack stack) {
+        this.permaItemsPurchased.add(stack);
     }
 
     public void storeInv() {
@@ -166,6 +179,7 @@ public class GamePlayer {
     public void clean() {
         invClean();
         resetLife();
+        resetPermaItems();
         new ArrayList<>(this.hiddenPlayers).forEach(this::showPlayer);
     }
 

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
@@ -321,6 +321,7 @@ public class PlayerListener implements Listener {
                         Debug.warn("You have wrongly configured gived-player-respawn-items!", true);
                     }
                 }
+                MiscUtils.giveItemsToPlayer(gPlayer.getPermaItemsPurchased(), gPlayer.player, team.getColor());
             }
         }
     }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/SpecialRegister.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/SpecialRegister.java
@@ -10,6 +10,7 @@ public class SpecialRegister {
         plugin.getServer().getPluginManager().registerEvents(new GolemListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new LuckyBlockAddonListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new MagnetShoesListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new PermaItemListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new ProtectionWallListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new RescuePlatformListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new TeamChestListener(), plugin);

--- a/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/PermaItemListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/special/listener/PermaItemListener.java
@@ -1,0 +1,105 @@
+package org.screamingsandals.bedwars.special.listener;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.screamingsandals.bedwars.Main;
+import org.screamingsandals.bedwars.api.APIUtils;
+import org.screamingsandals.bedwars.api.events.BedwarsApplyPropertyToBoughtItem;
+import org.screamingsandals.bedwars.game.GamePlayer;
+import org.screamingsandals.bedwars.lib.debug.Debug;
+
+import java.util.HashSet;
+
+public class PermaItemListener implements Listener {
+    private static final String PERMA_ITEM_PREFIX = "Module:PermaItem:";
+    private static final String PERMA_ITEM_PROPERTY_KEY = "lose-upon-death";
+    private static final HashSet<InventoryAction> blockedInventoryActions = initializeBlockedInventoryActions();
+
+    @EventHandler
+    public void onItemRegister(BedwarsApplyPropertyToBoughtItem event) {
+        GamePlayer gamePlayer = Main.getPlayerGameProfile(event.getPlayer());
+        if (event.hasProperty(PERMA_ITEM_PROPERTY_KEY)) {
+            if (!event.getBooleanProperty(PERMA_ITEM_PROPERTY_KEY)) {
+                ItemStack stack = event.getStack();
+
+                if (stack.getMaxStackSize() > 1) {
+                    Debug.warn(String.format("Item [%s] can be stacked and players will lose this item upon dying. Remove the 'lose-upon-death' flag for this item", stack), true);
+                    return;
+                }
+
+                APIUtils.hashIntoInvisibleString(stack, PERMA_ITEM_PREFIX);
+                gamePlayer.addPermaItem(stack);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onItemRemoval(InventoryClickEvent event) {
+        Player player = (Player) event.getWhoClicked();
+        if (!Main.isPlayerInGame(player)) {
+            return;
+        }
+
+        if (event.getClickedInventory() != null) {
+            if (event.getClickedInventory().getType() != InventoryType.PLAYER) {
+                return;
+            }
+        }
+
+        ItemStack cursorItem = event.getCursor();
+        ItemStack slotItem = event.getCurrentItem();
+        InventoryAction action = event.getAction();
+
+        String cursorItemUnhashedProp = null;
+        String slotItemUnhashedProp = null;
+
+        if (cursorItem != null) {
+            cursorItemUnhashedProp = APIUtils.unhashFromInvisibleStringStartsWith(cursorItem, PERMA_ITEM_PREFIX);
+        }
+
+        if (slotItem != null) {
+            slotItemUnhashedProp = APIUtils.unhashFromInvisibleStringStartsWith(slotItem, PERMA_ITEM_PREFIX);
+        }
+
+        if ((cursorItemUnhashedProp != null || slotItemUnhashedProp != null) && blockedInventoryActions.contains(action)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onItemDrop(PlayerDropItemEvent event) {
+        Player player = event.getPlayer();
+        if (!Main.isPlayerInGame(player)) {
+            return;
+        }
+        
+        Item droppedItem = event.getItemDrop();
+        String unhashedProperty = APIUtils.unhashFromInvisibleStringStartsWith(droppedItem.getItemStack(), PERMA_ITEM_PREFIX);
+        if (unhashedProperty != null) {
+            event.setCancelled(true);
+        }
+    }
+
+    private static HashSet<InventoryAction> initializeBlockedInventoryActions() {
+        HashSet<InventoryAction> blockedInventoryActions = new HashSet<>();
+
+        blockedInventoryActions.add(InventoryAction.DROP_ALL_CURSOR);
+        blockedInventoryActions.add(InventoryAction.DROP_ALL_SLOT);
+        blockedInventoryActions.add(InventoryAction.DROP_ONE_SLOT);
+        blockedInventoryActions.add(InventoryAction.DROP_ONE_CURSOR);
+        blockedInventoryActions.add(InventoryAction.MOVE_TO_OTHER_INVENTORY);
+
+        return blockedInventoryActions;
+    }
+
+    public static String getPermItemPropKey() {
+        return PERMA_ITEM_PROPERTY_KEY;
+    }
+}


### PR DESCRIPTION
## Description
This change adds the ability to make shop items permanent. To do this, you would just add the `lose-upon-death` property to an item in `shop.yml` and set it to `false`. If a player purchases a permanent item and dies, he/she will still have that item upon respawning. Here's a sample config:
```
  items:
   - price: 10 of iron
     skip: 1
     properties:
     - lose-upon-death: false
     stack:
      type: WOODEN_PICKAXE
      display-name: "Permanent Wooden Pickaxe"
      enchants:
       DIG_SPEED: 1
```
**Tested minecraft versions:** 1.16.4

### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [X] My code follows the code style of this project.
-   [X] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-- I'm not sure where the documentation is, but I'd be happy to update it
-   [ ] I have added tests to cover my changes.
-- Don't see any tests
-   [ ] All new and existing tests passed.
-- Don't see any tests