### PR TITLE
Support for Parties 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
         maven { url 'http://repo.onarandombox.com/content/groups/public'  }
         maven { url 'https://ci.frostcast.net/plugin/repository/everything'  }
         maven { url 'https://repo.codemc.org/repository/maven-public/'  }
+        maven { url 'https://repo.alessiodp.com/releases/'  }
         maven { url 'https://jitpack.io' }
         maven { url 'https://repo.citizensnpcs.co'  }
         /* Our gitlab repo for scoreboard lib*/

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     }
     compileOnly 'io.netty:netty-all:4.1.42.Final'
     compileOnly 'net.citizensnpcs:citizens-main:2.0.27-SNAPSHOT'
-    compileOnly 'com.alessiodp.parties:parties-api:2.6.16'
+    compileOnly 'com.alessiodp.parties:parties-api:3.0.0-rc.2'
 
     /* SHADED */
     shade project(':BedWars-API')

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/PartyCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/PartyCommand.java
@@ -32,12 +32,12 @@ public class PartyCommand extends BaseCommand {
             final var partyPlayer = partyApi.getPartyPlayer(player.getUniqueId());
             final var game = Main.getPlayerGameProfile(player).getGame();
 
-            if (partyPlayer.getPartyName().isEmpty()) {
+            if (partyPlayer.getPartyId() == null) {
                 player.sendMessage(i18n("party_command_not_in_party", true));
                 return true;
             }
 
-            final var party = partyApi.getParty(partyPlayer.getPartyName());
+            final var party = partyApi.getParty(partyPlayer.getPartyId());
 
             if (party != null) {
                 final var leaderUUID = party.getLeader();

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/PartyListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/PartyListener.java
@@ -1,7 +1,6 @@
 package org.screamingsandals.bedwars.listener;
 
 import com.alessiodp.parties.api.Parties;
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.screamingsandals.bedwars.Main;
@@ -24,8 +23,8 @@ public class PartyListener implements Listener {
 
         final var game = e.getGame();
 
-        if (!partyPlayer.getPartyName().isEmpty()) {
-            final var party = partyApi.getParty(partyPlayer.getPartyName());
+        if (partyPlayer.getPartyId() != null) {
+            final var party = partyApi.getParty(partyPlayer.getPartyId());
 
             if (party != null) {
                 final var leaderUUID = party.getLeader();

--- a/plugin/src/main/java/org/screamingsandals/bedwars/utils/MiscUtils.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/utils/MiscUtils.java
@@ -272,7 +272,7 @@ public class MiscUtils {
         }
     }
 
-    public static List<Player> getOnlinePlayers(List<UUID> uuids) {
+    public static List<Player> getOnlinePlayers(Collection<UUID> uuids) {
         if (uuids == null) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
## Description
Added support for Parties 3.0.0 (currently 3.0.0-rc.2).
This change supports 2 of Parties breaking changes:
- Now `Party.getMembers()` returns a Set instead of List (I changed `MiscUtils.getOnlinePlayers` method to support _Collections_ instead of _Lists_)
- Party names can be null, instead UUIDs are used

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
