### PR TITLE
Allowing multiple blocks in destroy-placed-blocks-by-explosion-except

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/config/MainConfig.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/config/MainConfig.java
@@ -93,7 +93,20 @@ public class MainConfig {
                 .key("disable-hunger").defValue(false)
                 .key("automatic-coloring-in-shop").defValue(true)
                 .key("sell-max-64-per-click-in-shop").defValue(true)
-                .key("destroy-placed-blocks-by-explosion-except").defValue("")
+                // .key("destroy-placed-blocks-by-explosion-except").defValue("")
+                .key("destroy-placed-blocks-by-explosion-except")
+                .remap(node -> {
+                    if (!node.empty() && !node.isList()) {
+                        var str = node.getString();
+                        try {
+                            var data = str == null ? List.of() : List.of(str);
+                            node.set(data);
+                        } catch(SerializationException ex) {
+                            ex.printStackTrace();
+                        }
+                    }
+                })
+                .defValue(List::of)
                 .key("destroy-placed-blocks-by-explosion").defValue(true)
                 .key("holo-above-bed").defValue(true)
                 .key("allow-spectator-join").defValue(false)

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
@@ -133,7 +133,7 @@ public class WorldListener implements Listener {
                             }
                             return true;
                         }
-                        return (explosionExceptionTypeName != null && !explosionExceptionTypeName.equals("") && block.getType().name().contains(explosionExceptionTypeName)) || !destroyPlacedBlocksByExplosion;
+                        return (explosionExceptionTypeName != null && !explosionExceptionTypeName.equals("") && explosionExceptionTypeName.contains(block.getType().name()) || !destroyPlacedBlocksByExplosion;
                     });
                 } else {
                     cancellable.setCancelled(true);

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/WorldListener.java
@@ -23,8 +23,10 @@ import org.screamingsandals.bedwars.api.game.GameStatus;
 import org.screamingsandals.bedwars.config.MainConfig;
 import org.screamingsandals.bedwars.game.GameManager;
 import org.screamingsandals.bedwars.utils.ArenaUtils;
+import org.spongepowered.configurate.ConfigurationNode;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class WorldListener implements Listener {
     @EventHandler
@@ -115,7 +117,7 @@ public class WorldListener implements Listener {
     }
 
     public void onExplode(Location location, List<Block> blockList, Cancellable cancellable) {
-        final var explosionExceptionTypeName = MainConfig.getInstance().node("destroy-placed-blocks-by-explosion-except").getString();
+        final var explosionExceptionTypeName = MainConfig.getInstance().node("destroy-placed-blocks-by-explosion-except").childrenList().stream().map(ConfigurationNode::getString).collect(Collectors.toList());
         final var destroyPlacedBlocksByExplosion = MainConfig.getInstance().node("destroy-placed-blocks-by-explosion").getBoolean(true);
 
         GameManager.getInstance().getGames().forEach(game -> {
@@ -133,7 +135,7 @@ public class WorldListener implements Listener {
                             }
                             return true;
                         }
-                        return (explosionExceptionTypeName != null && !explosionExceptionTypeName.equals("") && explosionExceptionTypeName.contains(block.getType().name()) || !destroyPlacedBlocksByExplosion;
+                        return (explosionExceptionTypeName != null && explosionExceptionTypeName.contains(block.getType().name())) || !destroyPlacedBlocksByExplosion;
                     });
                 } else {
                     cancellable.setCancelled(true);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changing the config key destroy-placed-blocks-by-explosion-except to an array, allowing people to add multiple blocks.
<!--- If it fixes an open issue, please link to the issue here. -->

**Tested minecraft versions:**

### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
