### PR TITLE
Remove need to super command name in admin commands

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/BaseCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/BaseCommand.java
@@ -23,6 +23,12 @@ public abstract class BaseCommand {
     protected final BedWarsPermission possiblePermission;
     protected final boolean allowConsole;
 
+    public BaseCommand(BedWarsPermission possiblePermission, boolean allowConsole) {
+        this.name = getClass().getSimpleName().toLowerCase().replaceAll("command", "");
+        this.possiblePermission = possiblePermission;
+        this.allowConsole = allowConsole;
+    }
+
     protected abstract void construct(Command.Builder<CommandSenderWrapper> commandSenderWrapperBuilder, CommandManager<CommandSenderWrapper> manager);
 
     @OnPostEnable

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/AddCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/AddCommand.java
@@ -16,7 +16,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class AddCommand extends BaseAdminSubCommand {
     public AddCommand() {
-        super("add");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/ArenaTimeCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/ArenaTimeCommand.java
@@ -12,7 +12,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class ArenaTimeCommand extends BaseAdminSubCommand {
     public ArenaTimeCommand() {
-        super("arenatime");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/ArenaWeatherCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/ArenaWeatherCommand.java
@@ -15,7 +15,7 @@ import java.util.stream.Stream;
 @Service
 public class ArenaWeatherCommand extends BaseAdminSubCommand {
     public ArenaWeatherCommand() {
-        super("arenaweather");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/BaseAdminSubCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/BaseAdminSubCommand.java
@@ -24,6 +24,10 @@ public abstract class BaseAdminSubCommand {
 
     private final String name;
 
+    public BaseAdminSubCommand() {
+        this.name = getClass().getSimpleName().toLowerCase().replaceAll("command", "");
+    }
+
     @OnPostEnable
     public void onPostEnable(@ProvidedBy(CommandService.class) CommandManager<CommandSenderWrapper> manager, @ProvidedBy(AdminCommand.class) Command.Builder<CommandSenderWrapper> builder) {
         construct(manager, builder.literal(name));

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/ConfigCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/ConfigCommand.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Service
 public class ConfigCommand extends BaseAdminSubCommand {
     public ConfigCommand() {
-        super("config");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/CustomPrefixCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/CustomPrefixCommand.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class CustomPrefixCommand extends BaseAdminSubCommand {
     public CustomPrefixCommand() {
-        super("customprefix");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/DisplayNameCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/DisplayNameCommand.java
@@ -13,7 +13,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class DisplayNameCommand extends BaseAdminSubCommand {
     public DisplayNameCommand() {
-        super("displayName");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/EditCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/EditCommand.java
@@ -12,7 +12,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class EditCommand extends BaseAdminSubCommand {
     public EditCommand() {
-        super("edit");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/GameBossBarColorCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/GameBossBarColorCommand.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 @Service
 public class GameBossBarColorCommand extends BaseAdminSubCommand {
     public GameBossBarColorCommand() {
-        super("gamebossbarcolor");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/InfoCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/InfoCommand.java
@@ -15,7 +15,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class InfoCommand extends BaseAdminSubCommand {
     public InfoCommand() {
-        super("info");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/JoinTeamCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/JoinTeamCommand.java
@@ -24,7 +24,7 @@ public class JoinTeamCommand extends BaseAdminSubCommand {
     public static final Map<UUID, TeamImpl> TEAMS_IN_HAND = new HashMap<>();
 
     public JoinTeamCommand() {
-        super("jointeam");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyBossBarColorCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyBossBarColorCommand.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 @Service
 public class LobbyBossBarColorCommand extends BaseAdminSubCommand {
     public LobbyBossBarColorCommand() {
-        super("lobbybossbarcolor");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyCommand.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class LobbyCommand extends BaseAdminSubCommand {
     public LobbyCommand() {
-        super("lobby");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyPos1Command.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyPos1Command.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class LobbyPos1Command extends BaseAdminSubCommand {
     public LobbyPos1Command() {
-        super("lobbypos1");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyPos2Command.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/LobbyPos2Command.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class LobbyPos2Command extends BaseAdminSubCommand {
     public LobbyPos2Command() {
-        super("lobbypos2");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/MinPlayersCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/MinPlayersCommand.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class MinPlayersCommand extends BaseAdminSubCommand {
     public MinPlayersCommand() {
-        super("minplayers");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/PausecountdownCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/PausecountdownCommand.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class PausecountdownCommand extends BaseAdminSubCommand {
     public PausecountdownCommand() {
-        super("pausecountdown");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/Pos1Command.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/Pos1Command.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class Pos1Command extends BaseAdminSubCommand {
     public Pos1Command() {
-        super("pos1");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/Pos2Command.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/Pos2Command.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class Pos2Command extends BaseAdminSubCommand {
     public Pos2Command() {
-        super("pos2");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/PostGameWaitingCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/PostGameWaitingCommand.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class PostGameWaitingCommand extends BaseAdminSubCommand {
     public PostGameWaitingCommand() {
-        super("postgamewaiting");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/RemoveCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/RemoveCommand.java
@@ -12,7 +12,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class RemoveCommand extends BaseAdminSubCommand {
     public RemoveCommand() {
-        super("remove");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/SaveCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/SaveCommand.java
@@ -12,7 +12,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class SaveCommand extends BaseAdminSubCommand {
     public SaveCommand() {
-        super("save");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/SpawnerCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/SpawnerCommand.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @Service
 public class SpawnerCommand extends BaseAdminSubCommand {
     public SpawnerCommand() {
-        super("spawner");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/SpecCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/SpecCommand.java
@@ -12,7 +12,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class SpecCommand extends BaseAdminSubCommand {
     public SpecCommand() {
-        super("spec");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/StoreCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/StoreCommand.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @Service
 public class StoreCommand extends BaseAdminSubCommand {
     public StoreCommand() {
-        super("store");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/TeamCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/TeamCommand.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 @Service
 public class TeamCommand extends BaseAdminSubCommand {
     public TeamCommand() {
-        super("team");
+        super();
     }
 
     @Override

--- a/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/TimeCommand.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/commands/admin/TimeCommand.java
@@ -11,7 +11,7 @@ import org.screamingsandals.lib.utils.annotations.Service;
 @Service
 public class TimeCommand extends BaseAdminSubCommand {
     public TimeCommand() {
-        super("time");
+        super();
     }
 
     @Override


### PR DESCRIPTION
## Description
In this pull request, I added the functionality where instead of supering the command name in the BaseCommand, it instead generates the name for you. It grabs the class, and then removes command, so if the class was "SaveCommand", it would output "save".

**Tested Minecraft versions:**
All, it's a small Java change, does not affect Minecraft itself.

### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
