### PR TITLE
Rearrenge TeamColor in numeric order and add Purple (Fix some chat/block color mismatch)

### DIFF
--- a/api/src/main/java/org/screamingsandals/bedwars/api/TeamColor.java
+++ b/api/src/main/java/org/screamingsandals/bedwars/api/TeamColor.java
@@ -37,5 +37,6 @@ public enum TeamColor {
     PINK,
     YELLOW,
     WHITE,
+    PURPLE,
     BROWN;
 }

--- a/plugin/src/main/java/org/screamingsandals/bedwars/game/TeamColor.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/game/TeamColor.java
@@ -26,21 +26,23 @@ import org.bukkit.inventory.ItemStack;
 import org.screamingsandals.bedwars.Main;
 
 public enum TeamColor {
-    BLACK(ChatColor.BLACK, 0xF, "BLACK", Color.BLACK),
-    BLUE(ChatColor.DARK_BLUE, 0xB, "BLUE", Color.fromRGB(0, 0, 170)),
+    WHITE(ChatColor.WHITE, 0x0, "WHITE", Color.WHITE),
+    ORANGE(ChatColor.GOLD, 0x1, "ORANGE", Color.fromRGB(255, 170, 0)),
+    MAGENTA(ChatColor.DARK_BLUE, 0x2, "MAGENTA", Color.fromRGB(170, 0, 170)),
+    LIGHT_BLUE(ChatColor.DARK_AQUA, 0x3, "LIGHT_BLUE", Color.fromRGB(85, 85, 255)),
+    YELLOW(ChatColor.YELLOW, 0x4, "YELLOW", Color.fromRGB(255, 255, 85)),
+    LIME(ChatColor.GREEN, 0x5, "LIME", Color.fromRGB(85, 255, 85)),
+    PINK(ChatColor.LIGHT_PURPLE, 0x6, "PINK", Color.fromRGB(255, 85, 255)),
+    GRAY(ChatColor.DARK_GRAY, 0x7, "GRAY", Color.fromRGB(85, 85, 85)),
+    LIGHT_GRAY(ChatColor.GRAY, 0x8, "LIGHT_GRAY", Color.fromRGB(170, 170, 170)),
+    CYAN(ChatColor.AQUA, 0x9, "CYAN", Color.fromRGB(85, 255, 255)),
+    PURPLE(ChatColor.DARK_PURPLE, 0xA, "PURPLE", Color.PURPLE),
+    BLUE(ChatColor.BLUE, 0xB, "BLUE", Color.fromRGB(0, 0, 170)),
+    BROWN(ChatColor.DARK_RED, 0xC, "BROWN", Color.fromRGB(139, 69, 19)),
     GREEN(ChatColor.DARK_GREEN, 0xD, "GREEN", Color.fromRGB(0, 170, 0)),
     RED(ChatColor.RED, 0xE, "RED", Color.fromRGB(255, 85, 85)),
-    MAGENTA(ChatColor.DARK_PURPLE, 0x2, "MAGENTA", Color.fromRGB(170, 0, 170)),
-    ORANGE(ChatColor.GOLD, 0x1, "ORANGE", Color.fromRGB(255, 170, 0)),
-    LIGHT_GRAY(ChatColor.GRAY, 0x8, "LIGHT_GRAY", Color.fromRGB(170, 170, 170)),
-    GRAY(ChatColor.DARK_GRAY, 0x7, "GRAY", Color.fromRGB(85, 85, 85)),
-    LIGHT_BLUE(ChatColor.BLUE, 0x3, "LIGHT_BLUE", Color.fromRGB(85, 85, 255)),
-    LIME(ChatColor.GREEN, 0x5, "LIME", Color.fromRGB(85, 255, 85)),
-    CYAN(ChatColor.AQUA, 0x9, "CYAN", Color.fromRGB(85, 255, 255)),
-    PINK(ChatColor.LIGHT_PURPLE, 0x6, "PINK", Color.fromRGB(255, 85, 255)),
-    YELLOW(ChatColor.YELLOW, 0x4, "YELLOW", Color.fromRGB(255, 255, 85)),
-    WHITE(ChatColor.WHITE, 0x0, "WHITE", Color.WHITE),
-    BROWN(ChatColor.DARK_RED, 0xC, "BROWN", Color.fromRGB(139,69,19));
+    BLACK(ChatColor.BLACK, 0xF, "BLACK", Color.BLACK);
+    
 
     public final ChatColor chatColor;
     public final String material1_13;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added the Purple color and modifier the named chat color assigned to a team to fit the block color more closely

ChatColor.BLUE was more close to BLUE_WOOL than LIGHT_BLUE_WOOL
<!--- If it fixes an open issue, please link to the issue here. -->

**Tested minecraft versions:**
1.18.1 / 1.16.5
### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
