### PR TITLE
Fix bug about team selection by not reusing team selector GUI

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/game/Game.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/game/Game.java
@@ -219,7 +219,7 @@ public class Game implements org.screamingsandals.bedwars.api.game.Game {
     private BukkitTask task;
     private List<CurrentTeam> teamsInGame = new ArrayList<>();
     private Region region = Main.isLegacy() ? new LegacyRegion() : new FlatteningRegion();
-    private TeamSelectorInventory teamSelectorInventory;
+    private List<TeamSelectorInventory> teamSelectorInventory = new ArrayList<>();
     private Scoreboard gameScoreboard = Bukkit.getScoreboardManager().getNewScoreboard();
     private StatusBar statusbar;
     private Map<Location, ItemStack[]> usedChests = new HashMap<>();
@@ -366,7 +366,9 @@ public class Game implements org.screamingsandals.bedwars.api.game.Game {
     }
 
     public TeamSelectorInventory getTeamSelectorInventory() {
-        return teamSelectorInventory;
+        TeamSelectorInventory gui = new TeamSelectorInventory(Main.getInstance(), this);
+        teamSelectorInventory.add(gui);
+        return gui;
     }
 
     public boolean isBlockAddedDuringGame(Location loc) {
@@ -1656,9 +1658,9 @@ public class Game implements org.screamingsandals.bedwars.api.game.Game {
                             .setStyle(BarStyle.valueOf(Main.getConfigurator().config.getString("bossbar.lobby.style")));
                 }
             }
-            if (teamSelectorInventory == null) {
-                teamSelectorInventory = new TeamSelectorInventory(Main.getInstance(), this);
-            }
+           // if (teamSelectorInventory == null) {
+           //     teamSelectorInventory = new TeamSelectorInventory(Main.getInstance(), this);
+           // }
             updateSigns();
         }
 
@@ -1795,9 +1797,7 @@ public class Game implements org.screamingsandals.bedwars.api.game.Game {
                                     BarStyle.valueOf(Main.getConfigurator().config.getString("bossbar.game.style")));
                         }
                     }
-                    if (teamSelectorInventory != null)
-                        teamSelectorInventory.destroy();
-                    teamSelectorInventory = null;
+                    teamSelectorInventory.forEach(gui->gui.destroy());
                     if (gameScoreboard.getObjective("lobby") != null) {
                         gameScoreboard.getObjective("lobby").unregister();
                     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix the bug preventing people from choosing teams with the GUI if 2 people have the same GUI open by not reusing GUIs
**Tested minecraft versions:**
1.19.2
### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
