### PR TITLE
more precise fractional levels

### DIFF
--- a/plugin/common/src/main/java/org/screamingsandals/bedwars/game/ItemSpawnerImpl.java
+++ b/plugin/common/src/main/java/org/screamingsandals/bedwars/game/ItemSpawnerImpl.java
@@ -364,13 +364,14 @@ public class ItemSpawnerImpl implements ItemSpawner, SerializableGameComponent {
 
                     var calculatedStack = (int) amountPerSpawn;
 
-                    /* Allow half level */
+                    /* fractional levels: have a weighted chance to increment */
+                    /* for example, 3.1 -> 10% chance for 4 and 90% chance for 3 */
                     if ((amountPerSpawn % 1) != 0) {
-                        int a = (int) Math.round(Math.random());
-                        if ((a % 2) == 0) {
+                        if (Math.random() < (amountPerSpawn % 1)) {
                             calculatedStack++;
                         }
                     }
+
                     var resourceSpawnEvent = new ResourceSpawnEventImpl(game, this, itemSpawnerType, itemSpawnerType.getItem(calculatedStack));
                     EventManager.fire(resourceSpawnEvent);
 


### PR DESCRIPTION
## Description

Allows for more precise fractional levels.

Previously, you can only use `.5` increments. For example, if `2.4` was the level of the generator, it would give `3` 40% of the time and `2` 60% of the time, or if `1.1` was the level, it would give `1` 90% of the time and `2` 10% of the time.

**Tested minecraft versions:**

1.18.2

### Screenshots (if appropriate)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
