### PR TITLE
Add player death cancelled support if version is Paper 1.13+

### DIFF
--- a/plugin/src/main/java/org/screamingsandals/bedwars/Main.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/Main.java
@@ -81,7 +81,7 @@ public class Main extends JavaPlugin implements BedwarsAPI {
     private static Main instance;
     private String version;
     private boolean isDisabling = false;
-    private boolean isSpigot, isLegacy;
+    private boolean isSpigot, isPaper, isLegacy;
     private boolean isVault;
     private int versionNumber = 0;
     private Economy econ = null;
@@ -131,6 +131,10 @@ public class Main extends JavaPlugin implements BedwarsAPI {
 
     public static boolean isSpigot() {
         return instance.isSpigot;
+    }
+
+    public static boolean isPaper() {
+        return instance.isPaper;
     }
 
     public static boolean isVault() {
@@ -362,6 +366,7 @@ public class Main extends JavaPlugin implements BedwarsAPI {
         version = this.getDescription().getVersion();
         boolean snapshot = version.toLowerCase().contains("pre") || version.toLowerCase().contains("snapshot");
         isSpigot = ClassStorage.IS_SPIGOT_SERVER;
+        isPaper = ClassStorage.IS_PAPER_SERVER;
         colorChanger = new org.screamingsandals.bedwars.utils.ColorChanger();
 
         if (!getServer().getPluginManager().isPluginEnabled("Vault")) {

--- a/plugin/src/main/java/org/screamingsandals/bedwars/lib/nms/utils/ClassStorage.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/lib/nms/utils/ClassStorage.java
@@ -32,6 +32,7 @@ import org.screamingsandals.bedwars.lib.nms.accessors.*;
 public class ClassStorage {
 
 	public static final boolean IS_SPIGOT_SERVER = safeGetClass("org.spigotmc.SpigotConfig") != null;
+	public static final boolean IS_PAPER_SERVER = safeGetClass("com.destroystokyo.paper.ParticleBuilder") != null;
 	public static final boolean HAS_CHUNK_TICKETS = getMethod(Chunk.class, "addPluginChunkTicket", Plugin.class).getReflectedMethod() != null;
 	
 	public static Class<?> safeGetClass(String... clazz) {

--- a/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
+++ b/plugin/src/main/java/org/screamingsandals/bedwars/listener/PlayerListener.java
@@ -74,6 +74,12 @@ public class PlayerListener implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
         final Player victim = event.getEntity();
 
+        if (!Main.isLegacy() && Main.isPaper()) {
+            if (event.isCancelled()) {
+                return;
+            }
+        }
+
         if (Main.isPlayerInGame(victim)) {
             GamePlayer gVictim = Main.getPlayerGameProfile(victim);
             Game game = gVictim.getGame();


### PR DESCRIPTION
:+1:

## Description
Check if the server is running paper 1.13 and above and if so check if the death event was canceled 

**Tested minecraft versions:**
Paper 1.21.1

### Types of changes
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
-   [x ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
